### PR TITLE
check to see if iconpickerValue exists before attempting to update parent element

### DIFF
--- a/src/js/iconpicker.js
+++ b/src/js/iconpicker.js
@@ -548,10 +548,12 @@
                 // Update selected item
                 this.iconpicker.find('.iconpicker-item.iconpicker-selected')
                     .removeClass('iconpicker-selected ' + this.options.selectedCustomClass);
-
-                this.iconpicker.find('.' + this.options.fullClassFormatter(this.iconpickerValue).replace(/ /g, '.')).parent()
-                    .addClass('iconpicker-selected ' + this.options.selectedCustomClass);
-
+                
+                if (this.iconpickerValue) {    
+                    this.iconpicker.find('.' + this.options.fullClassFormatter(this.iconpickerValue).replace(/ /g, '.')).parent()
+                        .addClass('iconpicker-selected ' + this.options.selectedCustomClass);
+                }
+                
                 // Update component item
                 if (this.hasComponent()) {
                     var icn = this.component.find('i');


### PR DESCRIPTION
The original code for the _updateComponents method was causing an error to be thrown (unrecognized expression ".fa.") by Sizzle inside of my Meteor project.
