### PR TITLE
Update iconpicker.less

### DIFF
--- a/src/less/iconpicker.less
+++ b/src/less/iconpicker.less
@@ -48,7 +48,7 @@
         width:@item_size;
         height:@item_size;
         padding: @base_spacing;
-        margin:0 @base_spacing @base_spacing 0;
+        margin:0 6px 6px 0; /* 4 cols of icons instead of 3 */
         text-align:center;
         cursor:pointer;
         border-radius:3px;


### PR DESCRIPTION
Using 6px as margin at the `.icon-picker-item` will result in 4 columns of icons instead of 3.