### PR TITLE
Use the latest metadata version to fetch icons.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,7 @@ module.exports = function(grunt) {
     grunt.initConfig({
         download: {
             somefile: {
-                src: ['https://raw.githubusercontent.com/FortAwesome/Font-Awesome/5.0.8/advanced-options/metadata/icons.yml'],
+                src: ['https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/advanced-options/metadata/icons.yml'],
                 dest: tempIconsFile
             },
         },


### PR DESCRIPTION
Fixes https://github.com/farbelous/fontawesome-iconpicker/issues/70.