### PR TITLE
Optimised loop in _createIconpicker

### DIFF
--- a/src/js/iconpicker.js
+++ b/src/js/iconpicker.js
@@ -239,28 +239,28 @@
                     }
                 };
 
+                var $itemElementTemplate = $(this.options.templates.iconpickerItem);
+                var $elementsToAppend = [];
                 for (var i in this.options.icons) {
                     if (typeof this.options.icons[i].title === 'string') {
-                        var itemElement = $(this.options.templates.iconpickerItem);
+                        var itemElement = $itemElementTemplate.clone();
                         itemElement.find('i')
                             .addClass(this.options.fullClassFormatter(this.options.icons[i].title));
                         itemElement.data('iconpickerValue', this.options.icons[i].title)
                             .on('click.iconpicker', itemClickFn);
-                        this.iconpicker.find('.iconpicker-items').append(itemElement
-                            .attr('title', '.' + this.options.icons[i].title));
 
+                        itemElement.attr('title', '.' + this.options.icons[i].title);
                         if (this.options.icons[i].searchTerms.length > 0) {
                             var searchTerms = '';
                             for (var j = 0; j < this.options.icons[i].searchTerms.length; j++) {
                                 searchTerms = searchTerms + this.options.icons[i].searchTerms[j] + ' ';
                             }
-                            this.iconpicker.find('.iconpicker-items').append(itemElement
-                                .attr('data-search-terms', searchTerms));
+                            itemElement.attr('data-search-terms', searchTerms);
                         }
-
+                        $elementsToAppend.push(itemElement);
                     }
                 }
-
+                this.iconpicker.find('.iconpicker-items').append($elementsToAppend);                
                 this.popover.find('.popover-content').append(this.iconpicker);
 
                 return this.iconpicker;


### PR DESCRIPTION
Hi first off all thanks for developing the iconpicker ;-)

This PR speeds up the loop which improves the initialization of the iconpicker 
The optimization address the following issues 
   * clone the precreated element (from the template) for each icon instead of creating it for each icon 
   * do not try to append the same itemElement twice
   * do not call **this.iconpicker.find('.iconpicker-items')** for every icon in the loop     
   * collect all icon elements and append them all in one operation outside the loop 
 
Before the optimization on demo page creating 8 instances (very large icon set) took ~11sec

<img width="1673" alt="screen shot 2018-11-03 at 11 53 07" src="https://user-images.githubusercontent.com/900118/47952730-f170db00-df6b-11e8-9b29-15b18b2cac6f.png">

After the same operation took ~3sec

<img width="1675" alt="screen shot 2018-11-03 at 11 55 04" src="https://user-images.githubusercontent.com/900118/47952731-f170db00-df6b-11e8-8140-815af9705371.png">

